### PR TITLE
Support all possible three-digit HTTP status codes

### DIFF
--- a/apachelogs/directives.py
+++ b/apachelogs/directives.py
@@ -4,8 +4,8 @@ from   .errors   import InvalidDirectiveError, UnknownDirectiveError
 from   .strftime import strftime2regex
 from   .timeutil import parse_apache_timestamp
 from   .util     import (FieldType, clf, clf_string, clf_word, cookie_value,
-                         esc_string, integer, ip_address, remote_user, uinteger,
-                         unescape)
+                         esc_string, integer, ip_address, remote_user,
+                         status_code, uinteger, unescape)
 
 PLAIN_DIRECTIVES = {
     '%': (None, FieldType('%', None)),
@@ -58,7 +58,7 @@ PLAIN_DIRECTIVES = {
     # httpd v2.4.29 has a provision in its code for converting statuses less
     # than or equal to zero to "-".  I'm not sure when that can happen, but
     # apparently it can.
-    's': ('status', clf(uinteger)),
+    's': ('status', clf(status_code)),
     't': (
         ('request_time_fields', 'timestamp'),
         FieldType(r'\[[^]]+\]', parse_apache_timestamp),

--- a/apachelogs/util.py
+++ b/apachelogs/util.py
@@ -78,6 +78,9 @@ integer    = FieldType(r'(?:0|-?[1-9][0-9]*)', int)
 #: `FieldType` instance for an unsigned base-10 integer
 uinteger   = FieldType(r'(?:0|[1-9][0-9]*)', int)
 
+#: `FieldType` instance for a 3-digit integer HTTP status code
+status_code = FieldType(r'[0-9]{3}', int)
+
 #: `FieldType` instance for a string containing escape sequences that is
 #: converted to `bytes`
 esc_string = FieldType(

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -96,6 +96,17 @@ from   apachelogs import COMBINED, VHOST_COMBINED, LogParser
     ),
 
     (
+        '%s',
+        '000',
+        {
+            "status": 000,
+            "directives": {
+                "%s": 000,
+            },
+        },
+    ),
+
+    (
         '%<{Referer}i %{Referer}i %>{Referer}i',
         'http://example.com/original http://example.com/default http://example.com/final',
         {


### PR DESCRIPTION
Currently the `%s` status code directive is parsed as a `uinteger`, which prevents parsing of unofficial status codes that begin with 0, and allows codes with more than three digits.

Per [IETF RFC 7231, section 6](https://tools.ietf.org/html/rfc7231#section-6):

> [t]he status code element is a three-digit integer code

Although there aren't any official codes starting with 0, various servers seem to use 000 if an HTTP connection is closed before the response can be fully returned: [Akamai](https://stackoverflow.com/q/9791684), [Cloudfront (page 271)](https://s3.amazonaws.com/awsdocs/CF/latest/cf_dg.pdf), old versions of [Nginx](http://hg.nginx.org/nginx/rev/aadfadd5af2b).

This commit creates a new type called `status_code`, which is explicitly a three-digit integer.